### PR TITLE
Genability client singleton

### DIFF
--- a/src/genability.ts
+++ b/src/genability.ts
@@ -1,0 +1,33 @@
+import { credentialsFromFile } from './rest-client/credentials';
+import { RestApiCredentials } from './rest-client';
+import { 
+  PropertyKeyApi
+} from './signal';
+
+export class GenabilityConfig {
+  profileName?: string;
+}
+
+export class Genability {
+  private static _instance: Genability;
+  private credentials: RestApiCredentials;
+
+  // REST APIs
+  private _properties: PropertyKeyApi | undefined;
+
+  private constructor(config?: Partial<GenabilityConfig>)
+  {
+    this.credentials = credentialsFromFile(config?.profileName);
+  }
+
+  public static configure(config?: Partial<GenabilityConfig>): Genability
+  {
+    return this._instance || (this._instance = new this(config));
+  }
+
+  public get properties(): PropertyKeyApi {
+    if(this._properties === undefined)
+      this._properties = new PropertyKeyApi(this.credentials)
+    return this._properties;
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,21 @@
 import { echoHello } from "./index";
+import { Genability, types, restApis } from "./index";
+
+describe("client", () => {
+  it("should init cleanly", async () => {
+
+    const genability: Genability = Genability.configure({
+      profileName: 'unitTest'
+    });
+    const demandPk = await genability.properties.getPropertyKey('demand');
+    expect(types.isGenPropertyKey(demandPk)).toBeTruthy;
+    const request = new restApis.GetPropertyKeysRequest();
+    request.dataType = types.DataType.DEMAND;
+    const demandPks = await genability.properties.getPropertyKeys(request);
+    expect(demandPks.results).toHaveLength(25);
+  })
+});
+
 
 describe("echoHello", () => {
   it("should default correctly", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
+import { Genability } from './genability'
 import * as types from './types';
+import * as restApis from './signal';
+import * as credentials from './rest-client/credentials';
 import * as restClient from './rest-client';
 import * as propertyKeyApi from './signal/property-key-api';
-import * as credentials from './rest-client/credentials';
 
 const world = 'World';
 
@@ -9,7 +11,11 @@ export function echoHello(word: string = world): string {
   return `Hello ${word}!`;
 }
 
+export { Genability };
 export { types };
+export { restApis };
+export { credentials };
+
+// TODO remove the following when CLI no longer uses them
 export { restClient };
 export { propertyKeyApi };
-export { credentials };

--- a/src/signal/index.ts
+++ b/src/signal/index.ts
@@ -1,0 +1,4 @@
+export { 
+  GetPropertyKeysRequest,
+  PropertyKeyApi
+} from './property-key-api';

--- a/src/signal/property-key-api.test.ts
+++ b/src/signal/property-key-api.test.ts
@@ -4,13 +4,11 @@ import {
 } from './property-key-api';
 import { PagedResponse } from '../rest-client'
 import {
-  ResourceTypes
-} from '../types';
-import {
+  ResourceTypes,
   GenPropertyKey,
   DataType,
   isGenPropertyKey
-} from '../types/property-key';
+} from '../types';
 import { credentialsFromFile } from '../rest-client/credentials';
 
 const credentials = credentialsFromFile('unitTest');

--- a/src/signal/property-key-api.ts
+++ b/src/signal/property-key-api.ts
@@ -8,7 +8,7 @@ import {
 import {
   GenPropertyKey,
   DataType
-} from '../types/property-key';
+} from '../types';
 
 export class GetPropertyKeysRequest extends BasePagedRequest {
   public excludeGlobal?: boolean;


### PR DESCRIPTION
Cleaner entry into the SDK library for outside client code. New Genability singleton class that can be passed a config object that all API calls will go though. Also restApis to access rest request and response classes.

example of new usage:

```
const genability: Genability = Genability.configure({
      profileName: 'unitTest'
    });
    const demandPk = await genability.properties.getPropertyKey('demand');
    expect(types.isGenPropertyKey(demandPk)).toBeTruthy;
    const request = new restApis.GetPropertyKeysRequest();
    request.dataType = types.DataType.DEMAND;
    const demandPks = await genability.properties.getPropertyKeys(request);
    expect(demandPks.results).toHaveLength(25);
```