### PR TITLE
Config interceptor fix

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.github
+webpack.config.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genability/api",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Node.js and Browser Javascript SDK for Genability APIs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/api/calculation-history-api.test.ts
+++ b/src/api/calculation-history-api.test.ts
@@ -4,7 +4,7 @@ import {
 } from './on-demand-cost-calculation-api';
 import {GetTariffsRequest, TariffApi} from './tariff-api'
 import {CalculationHistoryApi} from './calculation-history-api';
-import { credentialsFromFile } from '../rest-client/credentials';
+import { GenabilityConfig } from '../rest-client/config';
 import { SingleResponse, PagedResponse } from "../rest-client";
 import {
   CalculatedCost,
@@ -12,11 +12,10 @@ import {
 } from "../types/on-demand-cost-calculation";
 import {Tariff} from "../types";
 
-
-const credentials = credentialsFromFile('unitTest');
-const calculatedCostRestClient: CalculatedCostApi = new CalculatedCostApi(credentials);
-const tariffRestClient: TariffApi = new TariffApi(credentials);
-const restClient: CalculationHistoryApi = new CalculationHistoryApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const calculatedCostRestClient: CalculatedCostApi = new CalculatedCostApi(config);
+const tariffRestClient: TariffApi = new TariffApi(config);
+const restClient: CalculationHistoryApi = new CalculationHistoryApi(config);
 
 describe("Calculation history api", () => {
   it("should return calculated history response", async () => {
@@ -127,4 +126,3 @@ describe("Calculation history api", () => {
     }
   }, 40000);
 });
-

--- a/src/api/calculation-history-api.ts
+++ b/src/api/calculation-history-api.ts
@@ -1,18 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-ts-ignore */
 import {
-  RestApiClient,
-  RestApiCredentials,
-  GenabilityConfig,
+  RestApiClient
 } from '../rest-client';
 
 import {CalculatedCostRequest, CalculatedCost} from "../types/on-demand-cost-calculation";
 
 export class CalculationHistoryApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
-
   public async getCalculateHistoryResponse(requestId: string): Promise<CalculatedCost> {
     const response = await this.axiosInstance.get(`/beta/calculate/history/responses/${requestId}`);
     const responseData = response.data.results[0];

--- a/src/api/calendar-api.test.ts
+++ b/src/api/calendar-api.test.ts
@@ -3,7 +3,7 @@ import {
   GetCalendarsRequest,
   GetCalendarDatesRequest
 } from './calendar-api';
-import { isResponseError, PagedResponse } from '../rest-client'
+import { GenabilityConfig, isResponseError, PagedResponse } from '../rest-client'
 import {
   CalendarType,
   Calendar,
@@ -13,10 +13,9 @@ import {
   DateDefinitionType
 } from '../types/calendar';
 import { ResourceTypes } from '../types/resource-types';
-import { credentialsFromFile } from '../rest-client/credentials';
 
-const credentials = credentialsFromFile('unitTest');
-const restClient = new CalendarApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const restClient = new CalendarApi(config);
 
 describe("GetCalendarsRequest unit tests", () => {
   describe("call to queryStringify", () => {

--- a/src/api/calendar-api.ts
+++ b/src/api/calendar-api.ts
@@ -1,11 +1,9 @@
 import {
   RestApiClient,
-  RestApiCredentials,
   SingleResponse,
   PagedResponse,
   BasePagedRequest,
   AddParamCallback,
-  GenabilityConfig,
 } from '../rest-client';
 import {
   Calendar, CalendarType, DateDefinitionType, CalendarDate
@@ -42,11 +40,6 @@ export class GetCalendarDatesRequest extends BasePagedRequest {
 }
 
 export class CalendarApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
-
   public async getCalendars(request: GetCalendarsRequest): Promise<PagedResponse<Calendar>> {
     return this.getPaged(`/rest/public/calendars`, { params: request } );
   }

--- a/src/api/document-api.test.ts
+++ b/src/api/document-api.test.ts
@@ -3,17 +3,16 @@ import {
   GetDocumentsRequest,
   GetDocumentRequest
 } from './document-api';
-import { SingleResponse, PagedResponse } from '../rest-client'
+import { SingleResponse, PagedResponse, GenabilityConfig } from '../rest-client'
 import {
   Document,
   isDocument
 } from '../types/document';
 import { ResourceTypes } from "../types/resource-types";
-import { credentialsFromFile } from '../rest-client/credentials';
 import { Fields } from '../rest-client/contract';
 
-const credentials = credentialsFromFile('unitTest');
-const restClient = new DocumentApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const restClient = new DocumentApi(config);
 
 describe("GetDocuments request", () => {
   describe("call to queryStringify", () => {

--- a/src/api/document-api.ts
+++ b/src/api/document-api.ts
@@ -1,8 +1,6 @@
 import {
   RestApiClient,
-  RestApiCredentials,
   AddParamCallback,
-  GenabilityConfig,
   BasePagedRequest,
   PagedResponse,
   SingleResponse
@@ -30,10 +28,6 @@ export class GetDocumentRequest extends BasePagedRequest {
 }
 
 export class DocumentApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
 
   public async getDocuments(request: GetDocumentsRequest): Promise<PagedResponse<Document>> {
     return this.getPaged(`/v1/documents`, { params: request } );

--- a/src/api/load-serving-entity-api.test.ts
+++ b/src/api/load-serving-entity-api.test.ts
@@ -2,7 +2,7 @@ import {
   LoadServingEntityApi,
   GetLoadServingEntitiesRequest
 } from './load-serving-entity-api';
-import { SingleResponse, PagedResponse } from '../rest-client'
+import { SingleResponse, PagedResponse, GenabilityConfig } from '../rest-client'
 import {
   LoadServingEntity,
   ServiceType,
@@ -10,11 +10,10 @@ import {
   Ownership
 } from '../types/load-serving-entity';
 import { ResourceTypes } from '../types/resource-types'
-import { credentialsFromFile } from '../rest-client/credentials';
 import { Fields } from '../rest-client/contract';
 
-const credentials = credentialsFromFile('unitTest');
-const restClient = new LoadServingEntityApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const restClient = new LoadServingEntityApi(config);
 
 describe("GetLoadServingEntities request", () => {
   describe("call to queryStringify", () => {

--- a/src/api/load-serving-entity-api.ts
+++ b/src/api/load-serving-entity-api.ts
@@ -1,11 +1,9 @@
 import {
   RestApiClient,
-  RestApiCredentials,
   PagedResponse,
   SingleResponse,
   BasePagedRequest,
-  AddParamCallback,
-  GenabilityConfig
+  AddParamCallback
 } from '../rest-client';
 import {
   ServiceType,
@@ -28,11 +26,6 @@ export class GetLoadServingEntitiesRequest extends BasePagedRequest {
 }
 
 export class LoadServingEntityApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
-
   public async getLoadServingEntities(request: GetLoadServingEntitiesRequest): Promise<PagedResponse<LoadServingEntity>> {
     return this.getPaged(`/rest/public/lses`, { params: request } );
   }

--- a/src/api/lookup-api.test.ts
+++ b/src/api/lookup-api.test.ts
@@ -2,7 +2,7 @@ import {
   LookupApi,
   GetLookupsRequest
 } from './lookup-api';
-import { SingleResponse, PagedResponse } from '../rest-client'
+import { SingleResponse, PagedResponse, GenabilityConfig } from '../rest-client'
 import {
   LookupValue,
   isLookupValue,
@@ -10,10 +10,9 @@ import {
   isLookupStats
 } from '../types/lookup';
 import { ResourceTypes } from '../types/resource-types'
-import { credentialsFromFile } from '../rest-client/credentials';
 
-const credentials = credentialsFromFile('unitTest');
-const restClient = new LookupApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const restClient = new LookupApi(config);
 
 describe("Lookups request", () => {
   describe("call to queryStringify", () => {

--- a/src/api/lookup-api.ts
+++ b/src/api/lookup-api.ts
@@ -1,8 +1,6 @@
 import {
   RestApiClient,
-  RestApiCredentials,
   AddParamCallback,
-  GenabilityConfig,
   BasePagedRequest,
   PagedResponse,
   SingleResponse
@@ -26,11 +24,6 @@ export class GetLookupsRequest extends BasePagedRequest {
 }
 
 export class LookupApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
-
   public async getLookupValues(request?: GetLookupsRequest): Promise<PagedResponse<LookupValue>> {
     return this.getPaged('/rest/public/properties/lookups', { params: request } );
   }

--- a/src/api/on-demand-cost-calculation-api.test.ts
+++ b/src/api/on-demand-cost-calculation-api.test.ts
@@ -4,7 +4,7 @@ import {
   GetMassCalculationRequest,
 } from './on-demand-cost-calculation-api';
 import { TariffApi, GetTariffsRequest } from './tariff-api'
-import { SingleResponse, PagedResponse } from '../rest-client'
+import { SingleResponse, PagedResponse, GenabilityConfig } from '../rest-client'
 import {
   isCalculatedCost,
   CalculatedCost,
@@ -13,11 +13,10 @@ import {
 import {
   Tariff
 } from '../types/tariff';
-import { credentialsFromFile } from '../rest-client/credentials';
 
-const credentials = credentialsFromFile('unitTest');
-const restClient = new CalculatedCostApi(credentials);
-const tariffRestClient = new TariffApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const restClient = new CalculatedCostApi(config);
+const tariffRestClient = new TariffApi(config);
 
 describe("CalculatedCost api", () => {
   it("should return calculated cost", async () => {

--- a/src/api/on-demand-cost-calculation-api.ts
+++ b/src/api/on-demand-cost-calculation-api.ts
@@ -1,9 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-ignore */
 import {
   RestApiClient,
-  RestApiCredentials,
   SingleResponse,
-  GenabilityConfig,
 } from '../rest-client';
 
 import {
@@ -95,11 +93,6 @@ export class GetMassCalculationRequest implements CalculatedCostRequest {
 }
 
 export class CalculatedCostApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
-
   public async runCalculation(request: GetCalculatedCostRequest): Promise<SingleResponse<CalculatedCost>> {
     return this.post(`/rest/v1/ondemand/calculate`, request);
   }

--- a/src/api/property-key-api.test.ts
+++ b/src/api/property-key-api.test.ts
@@ -2,7 +2,7 @@ import {
   PropertyKeyApi, 
   GetPropertyKeysRequest 
 } from './property-key-api';
-import { SingleResponse, PagedResponse, isResponseError } from '../rest-client'
+import { SingleResponse, PagedResponse, isResponseError, GenabilityConfig } from '../rest-client'
 import {
   GenPropertyKey,
   PropertyDataType,
@@ -11,10 +11,9 @@ import {
 } from '../types/property-key';
 
 import { ResourceTypes } from "../types/resource-types";
-import { credentialsFromFile } from '../rest-client/credentials';
 
-const credentials = credentialsFromFile('unitTest');
-const restClient = new PropertyKeyApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const restClient = new PropertyKeyApi(config);
 
 const demandPk: GenPropertyKey = {
   dataType: PropertyDataType.DEMAND, 

--- a/src/api/property-key-api.ts
+++ b/src/api/property-key-api.ts
@@ -1,11 +1,9 @@
 import {
   RestApiClient,
-  RestApiCredentials,
   PagedResponse,
   SingleResponse,
   BasePagedRequest,
   AddParamCallback,
-  GenabilityConfig
 } from '../rest-client';
 import {
   GenPropertyKey,
@@ -31,11 +29,6 @@ export class GetPropertyKeysRequest extends BasePagedRequest {
 }
 
 export class PropertyKeyApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
-
   public async getPropertyKeys(request: GetPropertyKeysRequest): Promise<PagedResponse<GenPropertyKey>> {
     return this.getPaged(`/rest/public/properties`, { params: request } );
   }

--- a/src/api/season-api.test.ts
+++ b/src/api/season-api.test.ts
@@ -8,11 +8,10 @@ import {
   isSeason
 } from '../types/season';
 import { ResourceTypes } from '../types/resource-types'
-import { credentialsFromFile } from '../rest-client/credentials';
-import { PagedResponse } from '../rest-client';
+import { GenabilityConfig, PagedResponse } from '../rest-client'
 
-const credentials = credentialsFromFile('unitTest');
-const restClient = new SeasonGroupApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const restClient = new SeasonGroupApi(config);
 
 describe("call to queryStringify", () => {
   it("handles no parameters", async () => {

--- a/src/api/season-api.ts
+++ b/src/api/season-api.ts
@@ -1,8 +1,6 @@
 import {
   RestApiClient,
-  RestApiCredentials,
   AddParamCallback,
-  GenabilityConfig,
   BasePagedRequest,
   PagedResponse
 } from '../rest-client';
@@ -19,11 +17,6 @@ export class GetSeasonGroupsRequest extends BasePagedRequest {
 }
 
 export class SeasonGroupApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
-
   public async getSeasonGroups(request: GetSeasonGroupsRequest): Promise<PagedResponse<SeasonGroup>> {
     return this.getPaged(`/rest/public/seasons`, { params: request } );
   }

--- a/src/api/smart-price-api.test.ts
+++ b/src/api/smart-price-api.test.ts
@@ -2,14 +2,13 @@ import {
   SmartPriceApi,
   GetSmartPriceRequest
 } from './smart-price-api';
-import { PagedResponse } from '../rest-client'
+import { GenabilityConfig, PagedResponse } from '../rest-client'
 import { ResourceTypes } from "../types/resource-types";
-import { credentialsFromFile } from '../rest-client/credentials';
 import { Price, isPrice, isPriceChange } from '../types/smart-price';
 import { GroupBy } from '../types/on-demand-cost-calculation';
 
-const credentials = credentialsFromFile('unitTest');
-const restClient = new SmartPriceApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const restClient = new SmartPriceApi(config);
 
 describe("GetSmartPrice request", () => {
   describe("call to queryStringify", () => {

--- a/src/api/smart-price-api.ts
+++ b/src/api/smart-price-api.ts
@@ -42,11 +42,6 @@ export class GetSmartPriceRequest extends BasePagedRequest {
 }
 
 export class SmartPriceApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
-
   public async getSmartPrices(request?: GetSmartPriceRequest): Promise<PagedResponse<Price>> {
     return this.getPaged(`/rest/v1/prices/smart`, { params: request });
   }

--- a/src/api/smart-price-api.ts
+++ b/src/api/smart-price-api.ts
@@ -1,10 +1,8 @@
 import {
   RestApiClient,
-  RestApiCredentials,
   PagedResponse,
   BasePagedRequest,
   AddParamCallback,
-  GenabilityConfig,
 } from '../rest-client';
 import { Price } from '../types';
 import { GroupBy } from '../types/on-demand-cost-calculation';

--- a/src/api/tariff-api.test.ts
+++ b/src/api/tariff-api.test.ts
@@ -3,7 +3,7 @@ import {
   GetTariffsRequest,
   GetTariffRequest
 } from './tariff-api';
-import { SingleResponse, PagedResponse } from '../rest-client'
+import { SingleResponse, PagedResponse, GenabilityConfig } from '../rest-client'
 import {
   TariffType,
   CustomerClass,
@@ -13,13 +13,12 @@ import {
   isTariffDocument
 } from '../types/tariff';
 import { ResourceTypes } from "../types/resource-types";
-import { credentialsFromFile } from '../rest-client/credentials';
 import { ServiceType } from '../types/load-serving-entity';
 import { PrivacyFlag } from '../types/property-key';
 import { Fields } from '../rest-client/contract';
 
-const credentials = credentialsFromFile('unitTest');
-const restClient = new TariffApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const restClient = new TariffApi(config);
 
 describe("GetTariffs request", () => {
   describe("call to queryStringify", () => {

--- a/src/api/tariff-api.ts
+++ b/src/api/tariff-api.ts
@@ -1,10 +1,8 @@
 import {
   RestApiClient,
-  RestApiCredentials,
   PagedResponse,
   BasePagedRequest,
   AddParamCallback,
-  GenabilityConfig,
   SingleResponse
 } from '../rest-client';
 import {
@@ -109,11 +107,6 @@ export function tariffResponseInterceptor(response: AxiosResponse): void {
 }
 
 export class TariffApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
-
   public async getTariffs(request?: GetTariffsRequest): Promise<PagedResponse<Tariff>> {
     return this.getPaged(`/rest/public/tariffs`, { params: request }, tariffResponseInterceptor );
   }

--- a/src/api/territory-api.test.ts
+++ b/src/api/territory-api.test.ts
@@ -2,17 +2,16 @@ import {
   TerritoryApi,
   GetTerritoriesRequest
 } from './territory-api';
-import { PagedResponse, SingleResponse } from '../rest-client'
+import { GenabilityConfig, PagedResponse, SingleResponse } from '../rest-client'
 import { ResourceTypes } from '../types/resource-types'
 import {
   Territory,
   isTerritory,
   ItemType
 } from '../types/territory';
-import { credentialsFromFile } from '../rest-client/credentials';
 
-const credentials = credentialsFromFile('unitTest');
-const restClient = new TerritoryApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const restClient = new TerritoryApi(config);
 
 describe("GetTerritories request", () => {
   describe("call to queryStringify", () => {

--- a/src/api/territory-api.ts
+++ b/src/api/territory-api.ts
@@ -1,10 +1,8 @@
 import {
   RestApiClient,
-  RestApiCredentials,
   PagedResponse,
   BasePagedRequest,
   AddParamCallback,
-  GenabilityConfig,
   SingleResponse
 } from '../rest-client';
 import {
@@ -40,11 +38,6 @@ export class GetTerritoriesRequest extends BasePagedRequest {
 }
 
 export class TerritoryApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
-
   public async getTerritories(request: GetTerritoriesRequest): Promise<PagedResponse<Territory>> {
     return this.getPaged(`/rest/public/territories`, { params: request } );
   }

--- a/src/api/time-of-use-api.test.ts
+++ b/src/api/time-of-use-api.test.ts
@@ -5,12 +5,11 @@ import {
   isTimeOfUseGroup,
   isTimeOfUseInterval,
 } from '../types/time-of-use';
-import { credentialsFromFile } from '../rest-client/credentials';
-import { SingleResponse, PagedResponse } from '../rest-client';
+import { SingleResponse, PagedResponse, GenabilityConfig } from '../rest-client';
 import { ResourceTypes } from '../types/resource-types';
 
-const credentials = credentialsFromFile('unitTest');
-const restClient = new TimeOfUseApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const restClient = new TimeOfUseApi(config);
 
 describe("TimeOfUse api", () => {
   it("should returns a time of use group", async () => {

--- a/src/api/time-of-use-api.ts
+++ b/src/api/time-of-use-api.ts
@@ -1,7 +1,5 @@
 import {
   RestApiClient,
-  RestApiCredentials,
-  GenabilityConfig,
   PagedResponse,
   SingleResponse,
   DefaultPagedRequest
@@ -12,11 +10,6 @@ import {
 } from '../types';
 
 export class TimeOfUseApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
-
   public async getTimeOfUseGroups(lseId: number, request?: DefaultPagedRequest): Promise<PagedResponse<TimeOfUseGroup>> {
     return this.getPaged(`/rest/public/lses/${lseId}/tougroups`, { params: request });
   }

--- a/src/api/typical-baseline-api.test.ts
+++ b/src/api/typical-baseline-api.test.ts
@@ -2,14 +2,13 @@ import {
   TypicalBaselineApi,
   GetBaselinesBestRequest
 } from './typical-baseline-api';
-import { SingleResponse } from '../rest-client'
+import { GenabilityConfig, SingleResponse } from '../rest-client'
 import { Baseline, isBaseline, MeasureUnit } from '../types/typical-baseline';
 import { ServiceType } from '../types/load-serving-entity';
 import { ResourceTypes } from '../types/resource-types'
-import { credentialsFromFile } from '../rest-client/credentials';
 
-const credentials = credentialsFromFile('unitTest');
-const restClient = new TypicalBaselineApi(credentials);
+const config = new GenabilityConfig({profileName:'unitTest'});
+const restClient = new TypicalBaselineApi(config);
 
 describe("GetBaselinesBest request", () => {
   describe("call to queryStringify", () => {

--- a/src/api/typical-baseline-api.ts
+++ b/src/api/typical-baseline-api.ts
@@ -1,9 +1,7 @@
 import {
   RestApiClient,
-  RestApiCredentials,
   BasePagedRequest,
   AddParamCallback,
-  GenabilityConfig,
   SingleResponse
 } from '../rest-client';
 import {
@@ -53,11 +51,6 @@ export class GetBaselinesBestRequest extends BasePagedRequest {
 }
 
 export class TypicalBaselineApi extends RestApiClient {
-  public constructor(credentials: RestApiCredentials) {
-    const Config = GenabilityConfig.config();
-    super(Config.baseURL, credentials);
-  }
-
   public async getBestBaseline(request: GetBaselinesBestRequest): Promise<SingleResponse<Baseline>> {
     return this.getSingle('/rest/v1/typicals/baselines/best', { params: request } );
   }

--- a/src/genability.ts
+++ b/src/genability.ts
@@ -33,7 +33,7 @@ export class Genability {
 
   private constructor(options?: Partial<GenabilityConfigOptions>)
   {
-    this._config = GenabilityConfig.config(options);
+    this._config = new GenabilityConfig(options);
   }
 
   public static configure(config?: Partial<GenabilityConfigOptions>): Genability
@@ -43,62 +43,68 @@ export class Genability {
 
   public get properties(): PropertyKeyApi {
     if(this._properties === undefined)
-      this._properties = new PropertyKeyApi(this._config?.credentials)
+      this._properties = new PropertyKeyApi(this._config)
     return this._properties;
   }
 
   public get lses(): LoadServingEntityApi {
     if(this._lses === undefined)
-      this._lses = new LoadServingEntityApi(this._config?.credentials)
+      this._lses = new LoadServingEntityApi(this._config)
     return this._lses;
   }
 
   public get tariffs(): TariffApi {
     if(this._tariffs === undefined)
-      this._tariffs = new TariffApi(this._config?.credentials)
+      this._tariffs = new TariffApi(this._config)
     return this._tariffs;
   }
 
   public get calculation(): CalculatedCostApi {
     if(this._calculation === undefined)
-      this._calculation = new CalculatedCostApi(this._config?.credentials)
+      this._calculation = new CalculatedCostApi(this._config)
     return this._calculation;
   }
 
   public get territories(): TerritoryApi {
     if(this._territories === undefined)
-      this._territories = new TerritoryApi(this._config?.credentials)
+      this._territories = new TerritoryApi(this._config)
     return this._territories;
   }
 
   public get seasons(): SeasonGroupApi {
     if(this._seasons === undefined)
-      this._seasons = new SeasonGroupApi(this._config?.credentials)
+      this._seasons = new SeasonGroupApi(this._config)
     return this._seasons;
   }
 
   public get timeofuses(): TimeOfUseApi {
     if(this._timeofuses === undefined)
-      this._timeofuses = new TimeOfUseApi(this._config?.credentials)
+      this._timeofuses = new TimeOfUseApi(this._config)
     return this._timeofuses;
   }
 
   public get lookups(): LookupApi {
     if(this._lookups === undefined)
-      this._lookups = new LookupApi(this._config?.credentials)
+      this._lookups = new LookupApi(this._config)
     return this._lookups;
   }
 
   public get typicals(): TypicalBaselineApi {
     if(this._typicals === undefined)
-      this._typicals = new TypicalBaselineApi(this._config?.credentials)
+      this._typicals = new TypicalBaselineApi(this._config)
     return this._typicals;
   }
 
   public get documents(): DocumentApi {
     if(this._documents === undefined)
-      this._documents = new DocumentApi(this._config?.credentials)
+      this._documents = new DocumentApi(this._config)
     return this._documents;
+  }
+
+  // Return this instance's configuration object for testing/debug purposes
+
+  public get __config(): GenabilityConfig {
+    return this._config
   }
 
   // Reset the single instance for testing. TODO: Reconsider this design!

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,5 @@
 import { echoHello } from "./index";
 import { Genability, types, restApis } from "./index";
-import { GenabilityConfig } from "./rest-client";
 import { CommonPropertyKeyNames } from './types/property-key';
 
 describe("client", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,7 +6,6 @@ import { CommonPropertyKeyNames } from './types/property-key';
 describe("client", () => {
   afterEach(() => {
     Genability.__deconfigure();
-    GenabilityConfig.__deconfigure();
   });
 
   it("should init cleanly", async () => {
@@ -25,12 +24,11 @@ describe("client", () => {
   });
 
   it("should allow setting a proxy URL", async () => {
-    Genability.configure({
+    const client = Genability.configure({
       profileName: 'unitTest',
       proxy: 'https://test.com'
     });
-    const Config = GenabilityConfig.config();
-    expect(Config.baseURL).toBe('https://test.com');
+    expect(client.__config.baseURL).toBe('https://test.com');
   })
 });
 

--- a/src/rest-client/client.test.ts
+++ b/src/rest-client/client.test.ts
@@ -26,6 +26,7 @@ jest.mock('axios', () => {
   }
 });
 
+import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { GenabilityConfig } from '.';
 import {
   RestApiClient, RestApiCredentials, RestApiCredentialsObject
@@ -42,8 +43,8 @@ const jwtApiCredentials: RestApiCredentials = {
 
 const credentialsWithInterceptor = new GenabilityConfig({
   credentials: emptyApiCredentials,
-  requestInterceptor: (request) => request,
-  responseInterceptor: (response) => response
+  requestInterceptor: (request): AxiosRequestConfig => request,
+  responseInterceptor: (response): AxiosResponse => response
 });
 
 class TestClass extends RestApiClient{

--- a/src/rest-client/config.ts
+++ b/src/rest-client/config.ts
@@ -1,3 +1,4 @@
+import { AxiosAdapter, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { RestApiCredentials } from './client';
 import * as credentials from './credentials';
 
@@ -5,6 +6,8 @@ export class GenabilityConfigOptions {
   profileName?: string;
   proxy?: string;
   credentials?: RestApiCredentials;
+  requestInterceptor?: (requestConfig: AxiosRequestConfig) => AxiosRequestConfig;
+  responseInterceptor?: (response: AxiosResponse) => AxiosResponse;
 }
 
 export class GenabilityConfig {
@@ -14,10 +17,15 @@ export class GenabilityConfig {
     appId:'',
     appKey: ''
   };
+  private _requestInterceptor: ((requestConfig: AxiosRequestConfig) => AxiosRequestConfig) | undefined;
+  private _responseInterceptor: ((response: AxiosResponse) => AxiosResponse) | undefined;
 
-  private constructor(configOptions?: Partial<GenabilityConfigOptions>) {
+  constructor(configOptions?: Partial<GenabilityConfigOptions>) {
 
     this._baseURL = configOptions?.proxy ?? 'https://api.genability.com';
+
+    this._requestInterceptor = configOptions?.requestInterceptor;
+    this._responseInterceptor = configOptions?.responseInterceptor;
 
     // Deal with credentials last
 
@@ -39,10 +47,6 @@ export class GenabilityConfig {
     }
   }
 
-  public static config(configOptions?: Partial<GenabilityConfigOptions>): GenabilityConfig {
-    return this._instance || (this._instance = new this(configOptions));
-  }
-
   get baseURL(): string {
     return this._baseURL;
   }
@@ -51,10 +55,11 @@ export class GenabilityConfig {
     return this._credentials;
   }
 
-  // Reset the single instance for testing. TODO: Reconsider this design!
+  get requestInterceptor(): ((requestConfig: AxiosRequestConfig) => AxiosRequestConfig) | undefined {
+    return this._requestInterceptor;
+  }
 
-  public static __deconfigure(): void
-  {
-    delete this._instance;
+  get responseInterceptor(): ((response: AxiosResponse) => AxiosResponse) | undefined {
+    return this._responseInterceptor;
   }
 }

--- a/src/rest-client/config.ts
+++ b/src/rest-client/config.ts
@@ -1,4 +1,4 @@
-import { AxiosAdapter, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { RestApiCredentials } from './client';
 import * as credentials from './credentials';
 

--- a/src/rest-client/contract.ts
+++ b/src/rest-client/contract.ts
@@ -216,7 +216,7 @@ abstract class BaseResponse<T>implements Response<T> {
 }
 
 export class DefaultPagedRequest extends BasePagedRequest {
-  addParams(addParam: AddParamCallback): void {
+  addParams(addParam: AddParamCallback): void { // eslint-disable-line @typescript-eslint/no-unused-vars
     // no-op, we only want the default pagination, search & sort params
   }
 }

--- a/src/types/tariff.ts
+++ b/src/types/tariff.ts
@@ -229,8 +229,8 @@ export function toTariffFromApi(json: any): Tariff {
   return json as Tariff;
 }
 
-export function toApiFromTariff(tariff: Tariff): {[key: string]: any} {
-  const returnJson = {...tariff} as {[key: string]: any};
+export function toApiFromTariff(tariff: Tariff): {[key: string]: any} { // eslint-disable-line @typescript-eslint/no-explicit-any
+  const returnJson = {...tariff} as {[key: string]: any}; // eslint-disable-line @typescript-eslint/no-explicit-any
   if(returnJson.rates) {
     for(const tariffRate of returnJson.rates) {
       if(tariffRate && tariffRate.chargeClass) {


### PR DESCRIPTION
- Remove singleton pattern from config
- Make APIs take a single Config object in the constructor
- Add interceptors for requests and responses as top-level options to the config object