### PR TITLE
GEN-2354 add super peak types to TimeOfUse enums

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genability/api",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "description": "Node.js and Browser Javascript SDK for Genability APIs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genability/api",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Node.js and Browser Javascript SDK for Genability APIs.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/types/tariff-graphql.ts
+++ b/src/types/tariff-graphql.ts
@@ -70,7 +70,9 @@ export const tariffGraphQLSchema = gql`
     ON_PEAK,
     PARTIAL_PEAK,
     OFF_PEAK,
-    CRITICAL_PEAK
+    CRITICAL_PEAK,
+    SUPER_OFF_PEAK,
+    SUPER_ON_PEAK
   }
 
   enum RateUnit {

--- a/src/types/tariff.ts
+++ b/src/types/tariff.ts
@@ -76,6 +76,8 @@ export enum TimeOfUseType {
   PARTIAL_PEAK = "PARTIAL_PEAK",
   OFF_PEAK = "OFF_PEAK",
   CRITICAL_PEAK = "CRITICAL_PEAK",
+  SUPER_OFF_PEAK = "SUPER_OFF_PEAK",
+  SUPER_ON_PEAK = "SUPER_ON_PEAK",
 }
 
 export enum RateUnit {


### PR DESCRIPTION
This PR adds the Super on and off peak types to the TimeOfUseType enum and the corresponding type in the graphQL schema. This is in support of the larger https://genability.atlassian.net/browse/GEN-2335 changes.