### PR TITLE
GEN-2334 Add CCA and Behind meter ownership types to ownership type/enum

### DIFF
--- a/src/types/load-serving-entity-graphql.ts
+++ b/src/types/load-serving-entity-graphql.ts
@@ -23,7 +23,9 @@ export const lseGraphQLSchema = gql`
     WHOLESALE_ENERGY_MARKETER,
     TRANSMISSION,
     STATE,
-    UNREGULATED
+    UNREGULATED,
+    BEHIND_METER,
+    COMMUNITY_CHOICE_AGGREGATOR
   }
 
   type LoadServingEntity {

--- a/src/types/load-serving-entity.ts
+++ b/src/types/load-serving-entity.ts
@@ -21,7 +21,9 @@ export enum Ownership {
   TRANSMISSION = "TRANSMISSION",
   STATE = "STATE",
   UNREGULATED = "UNREGULATED",
-};
+  BEHIND_METER = "BEHIND_METER",
+  COMMUNITY_CHOICE_AGGREGATOR = "COMMUNITY_CHOICE_AGGREGATOR",
+}
 
 export interface LoadServingEntity {
   lseId: number;


### PR DESCRIPTION
In line with the addition of the Community Choice Aggregator ownership type introduced in https://github.com/Genability/Family/pull/877, adding the new ownership type as a valid value in the Ownership enum (TS and graphQL).

While here, noticed that the Behind Meter ownership type was never added, so adding that now as well.

There do not appear to be any tests that specifically cover all possible ownership values.