### PR TITLE
Lookups now require a keyName. Adjusting old test to enforce this.

### DIFF
--- a/src/api/lookup-api.test.ts
+++ b/src/api/lookup-api.test.ts
@@ -70,7 +70,7 @@ describe('Lookup api', () => {
     const emptyRequest = new GetLookupsRequest('will be cleared');
     emptyRequest.keyName = '';
 
-    expect(restClient.getLookupValues(emptyRequest)).rejects.toEqual('keyName is required');
+    expect(restClient.getLookupValues(emptyRequest)).rejects.toEqual('[Error: keyName is required]');
   })
   it('should returns a specific choice for a keyName', async () => {
     const response: PagedResponse<LookupValue> = await restClient.getPropertyLookupValues('hourlyPricingDayAheadERCOT');

--- a/src/api/lookup-api.test.ts
+++ b/src/api/lookup-api.test.ts
@@ -1,4 +1,4 @@
-import { 
+import {
   LookupApi,
   GetLookupsRequest
 } from './lookup-api';
@@ -64,17 +64,14 @@ describe('Lookup api', () => {
     }
     restClient = new LookupApi(config);
   });
-  // TODO this has to be enabled once when the ticket "GEN-3711" gets addressed. Disabling the test case disabled due to a gateway error in the public/properties/lookups end point
-  // it('should returns all lookups', async () => {
-  //   const response: PagedResponse<LookupValue> = await restClient.getLookupValues();
-  //   expect(response.status).toEqual('success');
-  //   expect(response.type).toEqual(ResourceTypes.PROPERTY_LOOKUP);
-  //   expect(response.count).toBeGreaterThan(200);
-  //   expect(response.results).toHaveLength(25);
-  //   for(const lookup of response.results) {
-  //     expect(isLookupValue(lookup)).toBeTruthy();
-  //   }
-  // }, 10000)
+  it('lookups require a keyName', async () => {
+    // Typescript prevents null/undefined keyName.
+    // Dance around constructor validation to still send in an empty keyName
+    const emptyRequest = new GetLookupsRequest('will be cleared');
+    emptyRequest.keyName = '';
+
+    expect(restClient.getLookupValues(emptyRequest)).rejects.toEqual('keyName is required');
+  })
   it('should returns a specific choice for a keyName', async () => {
     const response: PagedResponse<LookupValue> = await restClient.getPropertyLookupValues('hourlyPricingDayAheadERCOT');
     expect(response.status).toEqual('success');

--- a/src/api/lookup-api.test.ts
+++ b/src/api/lookup-api.test.ts
@@ -70,7 +70,7 @@ describe('Lookup api', () => {
     const emptyRequest = new GetLookupsRequest('will be cleared');
     emptyRequest.keyName = '';
 
-    expect(restClient.getLookupValues(emptyRequest)).rejects.toEqual('[Error: keyName is required]');
+    expect(restClient.getLookupValues(emptyRequest)).rejects.toEqual(new Error('keyName is required'));
   })
   it('should returns a specific choice for a keyName', async () => {
     const response: PagedResponse<LookupValue> = await restClient.getPropertyLookupValues('hourlyPricingDayAheadERCOT');

--- a/src/api/lookup-api.ts
+++ b/src/api/lookup-api.ts
@@ -41,10 +41,10 @@ export class GetLookupsRequest extends BasePagedRequest {
   }
 }
 
-export class LookupApi extends RestApiClient { 
+export class LookupApi extends RestApiClient {
   public async getLookupValues(request: GetLookupsRequest): Promise<PagedResponse<LookupValue>> {
     const keyName = request.keyName;
-    if (!keyName) {
+    if (!keyName || !keyName.trim()) {
       throw new Error('keyName is required');
     }
     return this.getPaged(`/rest/public/properties/${keyName}/lookups`, { params: request } );


### PR DESCRIPTION
Followup/cleanup from https://github.com/Genability/genability-js/pull/280